### PR TITLE
Version 1.0.1

### DIFF
--- a/.conf/prod_config.json
+++ b/.conf/prod_config.json
@@ -2,6 +2,7 @@
   "server": 828122715780939786,
   "log_channel": 1016982786059542559,
   "max_messages": 300000,
+  "backlog_length": 30,
   "log_history": 3,
   "ignored_categories": [858060453607374860, 910345180593414194]
 }

--- a/.conf/prod_config.json
+++ b/.conf/prod_config.json
@@ -1,8 +1,10 @@
 {
+  "token": "TOKEN",
   "server": 828122715780939786,
   "log_channel": 1016982786059542559,
   "max_messages": 300000,
   "backlog_length": 30,
   "log_history": 3,
-  "ignored_categories": [858060453607374860, 910345180593414194]
+  "ignored_categories": [858060453607374860, 910345180593414194],
+  "read_cache_file": false
 }

--- a/.conf/test_config.json
+++ b/.conf/test_config.json
@@ -2,6 +2,7 @@
   "server": 790789893071962132,
   "log_channel": 1017687912000790588,
   "max_messages": 300000,
+  "backlog_length": 30,
   "log_history": 3,
   "ignored_categories": [1017687958171680779]
 }

--- a/.conf/test_config.json
+++ b/.conf/test_config.json
@@ -1,8 +1,10 @@
 {
+  "token": "TEST_TOKEN",
   "server": 790789893071962132,
   "log_channel": 1017687912000790588,
   "max_messages": 300000,
   "backlog_length": 30,
   "log_history": 3,
-  "ignored_categories": [1017687958171680779]
+  "ignored_categories": [1017687958171680779],
+  "read_cache_file": true
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
-# Celestia
+# Celestia-Bot
 UW Genshin Discord's custom moderation bot.
+
 Celestia monitors and logs edit and delete actions on the server for the purposes of accountability and safety.
+For questions about the bot, please contact RicePulp#0077 and/or Purost#1025.
+
+## Version 1.0.0
+Initial release.
+
+## Version 1.0.1
+### Features
+- Added the ability for Celestia to write the current cache to a .txt file. This is expected to improve back-logging 
+performance for future boot performance.
+- Added the ability for Celestia to ignore certain categories as defined in the .conf/config file. This is expected to 
+improve boot performance for back-logging by ignoring channels that do not require monitoring.
+### Bug fixes
+- Fixed an issue that caused Discord-triggered embed edits to appear as edits triggered by the poster.
+- Fixed an issue that caused Celestia to error out on post deletion if previous messages had empty bodies 
+(e.g. a sticker-only message).
+### Other changes
+- Temporarily reverted the ability for Celestia to post a sticker image in a delete log, instead posting the sticker 
+name surrounded by colons as if it were an emote.
+  - The motivation for this change is that embeds do not support forcing image dimensions, which could result in visually
+  very large images being included in logs. A better solution for stickers is being worked on.
+- Changed the indication of a message with empty body from "_\[Empty message\]_" to "_\[Empty message body\]_" for clarity.
+  - "Empty message body" clarifies that the message has no text, but could have, for example, attachments or stickers.
+- Various consistency and quality of life changes.
+### Known issues
+- Celestia's error logs are suboptimal and could provide more information or context about errors.
+- The edit embed displays attachments illogically and should display "Attachments before edit" directly after the "Before"
+section. It should also display the attachments remaining after the edit.
+- Currently, after a message is deleted, the message cache still lives in the internal cache, which is an unnecessary
+use of resources.
+- The bot is currently hosted locally, and is planned to be migrated to a hosting service. This change will occur with 
+Version 1.1.0.

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ config_file = open('.conf/prod_config.json')
 config = json.load(config_file)
 server: int = int(config['server'])
 max_messages: int = int(config['max_messages'])
+backlog_length: int = int(config['backlog_length'])
 log_channel: int = int(config['log_channel'])
 log_history: int = int(config['log_history'])
 ignored_categories: list[int] = config['ignored_categories']
@@ -106,7 +107,7 @@ async def populate_cache():
             if channel.type == discord.ChannelType.text and channel.category_id not in ignored_categories:
                 print(f'Caching channel {channel.name}')
                 message_iterator = channel.history(limit=None,
-                                                   after=datetime.datetime.now() - datetime.timedelta(days=30))
+                                                   after=datetime.datetime.now() - datetime.timedelta(days=backlog_length))
                 while True:
                     try:
                         next_message: discord.Message = await anext(message_iterator)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,12 @@
+# Celestia Bot
+# Version 1.0.1
+
 import os
 import time
 import traceback
 
 import discord
+from discord.ext import tasks
 import json
 import datetime
 
@@ -13,14 +17,16 @@ from message_cache import MessageCache
 
 # read config
 load_dotenv()
-config_file = open('.conf/prod_config.json')
+config_file = open('.conf/test_config.json')
 config = json.load(config_file)
+token: str = config['token']
 server: int = int(config['server'])
 max_messages: int = int(config['max_messages'])
 backlog_length: int = int(config['backlog_length'])
 log_channel: int = int(config['log_channel'])
 log_history: int = int(config['log_history'])
 ignored_categories: list[int] = config['ignored_categories']
+read_cache_file: bool = config['read_cache_file']
 
 # cache
 message_cache: MessageCache = MessageCache(max_cache_size=max_messages)
@@ -32,7 +38,7 @@ pst = datetime.timezone(-datetime.timedelta(hours=8))
 is_setting_up = True
 
 # bot setup
-bot_token: str = os.getenv('TOKEN')
+bot_token: str = os.getenv(token)
 bot: discord.Client = discord.Client(intents=discord.Intents.all(), status=discord.Status.online,
                                      activity=discord.Activity(type=discord.ActivityType.watching,
                                                                name='over the server'))
@@ -58,19 +64,19 @@ async def create_delete_log_embed(message: MessageModel) -> discord.Embed:
             if previous_message.type != discord.MessageType.default:
                 continue
             embed.insert_field_at(index=0, name=previous_message.author.name,
-                                  value=previous_message.content,
+                                  value=get_message_content(previous_message),
                                   inline=False)
             first_message_url = previous_message.jump_url
         except StopAsyncIteration:
             break
     if first_message_url is not None:
         embed.url = first_message_url
-    embed.add_field(name=f'Deleted message - {author.name}', value=message.content,
+    embed.add_field(name=f'Deleted message - {author.name}', value=await get_message_model_content(message),
                     inline=False)
     if len(message.attachments) > 0:
         embed.add_field(name='Attachments', value='\n'.join(message.attachments), inline=False)
-    if message.sticker != '':
-        embed.set_image(url=message.sticker)
+    #    if message.sticker != '':
+    #        embed.set_image(url=message.sticker)
     embed.set_footer(text=f'Deleted at {datetime.datetime.now(get_timezone()).isoformat(sep=" ", timespec="seconds")}')
     return embed
 
@@ -88,30 +94,49 @@ async def create_edit_log_embed(before: MessageModel, after: MessageModel) -> di
                      icon_url=author.display_avatar.url)
     embed.url = (await channel.get_partial_message(after.message_id).fetch()).jump_url
     embed.add_field(name=f'Before',
-                    value=before.content, inline=False)
-    embed.add_field(name=f'After', value=after.content, inline=False)
+                    value=await get_message_model_content(before), inline=False)
+    embed.add_field(name=f'After', value=get_message_model_content(after), inline=False)
     if len(before.attachments) > 0:
         embed.add_field(name='Attachments before edit', value='\n'.join(before.attachments), inline=False)
-    if before.sticker != '':
-        embed.set_image(url=before.sticker)
+    #    if before.sticker != '':
+    #        embed.set_image(url=before.sticker)
     embed.set_footer(text=f'Edited at {datetime.datetime.now(get_timezone()).isoformat(sep=" ", timespec="seconds")}')
     return embed
 
 
+async def get_message_model_content(message: MessageModel) -> str:
+    return message.content + ('' if message.sticker == 0 else f'\n:{await bot.fetch_sticker(message.sticker)}:')
+
+
+def get_message_content(message: discord.Message) -> str:
+    return ((message.content if message.content == '' else "*[Empty message body]*") +
+            ('' if len(message.stickers) == 0 else f'\n:{message.stickers[0].name}:'))
+
+
 async def populate_cache():
-    global is_setting_up
+    global is_setting_up, message_cache
+    if read_cache_file:
+        try:
+            cache_file = open(".cache/cache.txt")
+            cache_object = json.load(cache_file)
+            message_cache = MessageCache(max_cache_size=max_messages, cache=cache_object)
+            print("Loaded cache file")
+        except json.decoder.JSONDecodeError:
+            print("Failed to read cache file")
     guild: discord.Guild = bot.get_guild(server)
+    time_start = max([datetime.datetime.now(get_timezone()) - datetime.timedelta(days=backlog_length),
+                      message_cache.get_max_time(get_timezone())])
     if guild is not None:
         channels = guild.channels
         for channel in channels:
             if channel.type == discord.ChannelType.text and channel.category_id not in ignored_categories:
                 print(f'Caching channel {channel.name}')
-                message_iterator = channel.history(limit=None,
-                                                   after=datetime.datetime.now() - datetime.timedelta(days=backlog_length))
+                message_iterator = channel.history(limit=None, after=time_start)
                 while True:
                     try:
                         next_message: discord.Message = await anext(message_iterator)
-                        message_cache.add_message_model(MessageModel(next_message), append=False)
+                        if not next_message.author.bot and next_message.type == discord.MessageType.default:
+                            message_cache.add_message_model(MessageModel(next_message), append=False)
                     except StopAsyncIteration:
                         break
                     except discord.errors.Forbidden:
@@ -133,8 +158,8 @@ def print_metrics():
     print(f'Average entry size: {round(size / length, 2)}')
 
 
-def get_unix_time() -> float:
-    return datetime.datetime.timestamp(datetime.datetime.now())
+def get_unix_time(time: datetime.datetime) -> float:
+    return datetime.datetime.timestamp(time)
 
 
 def is_daylight_savings() -> bool:
@@ -143,6 +168,10 @@ def is_daylight_savings() -> bool:
 
 def get_timezone() -> datetime.tzinfo:
     return pdt if is_daylight_savings() else pst
+
+
+def to_json(obj):
+    return json.dumps(obj, default=lambda o: o.__dict__, indent=4)
 
 
 @bot.event
@@ -154,7 +183,7 @@ async def on_raw_message_edit(payload: discord.RawMessageUpdateEvent):
                 return
             after = MessageModel(after_message)
             before = message_cache.get_message_model(message=after, update=True)
-            if before is not None:
+            if before is not None and not before.total_eq(after):
                 embed = await create_edit_log_embed(before=before, after=after)
                 await bot.get_channel(log_channel).send(embed=embed)
     except:
@@ -180,7 +209,9 @@ async def on_raw_message_delete(payload: discord.RawMessageDeleteEvent):
 async def on_message(message: discord.Message):
     global i
     try:
-        if (not message.author.bot) and message.guild.id == server and message.channel.category_id not in ignored_categories:
+        if ((not message.author.bot) and message.guild.id == server
+                and message.channel.category_id not in ignored_categories
+                and message.type == discord.MessageType.default):
             message_cache.add_message_model(MessageModel(message=message))
             i = i + 1
             if i % 100 == 0:
@@ -189,14 +220,23 @@ async def on_message(message: discord.Message):
         await notify_error(traceback.format_exc(limit=None))
 
 
+@tasks.loop(hours=1)
+async def print_cache():
+    cache_file = open(".cache/cache.txt", "w")
+    cache_file.write(to_json(message_cache.get_cache()))
+    cache_file.close()
+    print(f'Wrote to cache at {datetime.datetime.now().isoformat()}')
+
+
 @bot.event
 async def on_ready():
     try:
         print('We have logged in as {0.user}'.format(bot))
-        populate_time = get_unix_time()
+        populate_time = get_unix_time(datetime.datetime.now())
         print('Populating cache')
         await populate_cache()
-        print(f'Cache populated in {round(get_unix_time() - populate_time, 3)} seconds')
+        print(f'Cache populated in {round(get_unix_time(datetime.datetime.now()) - populate_time, 3)} seconds')
+        print_cache.start()
         print_metrics()
         await bot.get_channel(log_channel).send(content='Celestia has booted up and is now '
                                                         'monitoring edits and deletions.')


### PR DESCRIPTION
## Version 1.0.1
### Features
- Added the ability for Celestia to write the current cache to a .txt file. This is expected to improve back-logging 
performance for future boot performance.
- Added the ability for Celestia to ignore certain categories as defined in the .conf/config file. This is expected to 
improve boot performance for back-logging by ignoring channels that do not require monitoring.
### Bug fixes
- Fixed an issue that caused Discord-triggered embed edits to appear as edits triggered by the poster.
- Fixed an issue that caused Celestia to error out on post deletion if previous messages had empty bodies 
(e.g. a sticker-only message).
### Other changes
- Temporarily reverted the ability for Celestia to post a sticker image in a delete log, instead posting the sticker 
name surrounded by colons as if it were an emote.
  - The motivation for this change is that embeds do not support forcing image dimensions, which could result in visually
  very large images being included in logs. A better solution for stickers is being worked on.
- Changed the indication of a message with empty body from "_\[Empty message\]_" to "_\[Empty message body\]_" for clarity.
  - "Empty message body" clarifies that the message has no text, but could have, for example, attachments or stickers.
- Various consistency and quality of life changes.
### Known issues
- Celestia's error logs are suboptimal and could provide more information or context about errors.
- The edit embed displays attachments illogically and should display "Attachments before edit" directly after the "Before"
section. It should also display the attachments remaining after the edit.
- Currently, after a message is deleted, the message cache still lives in the internal cache, which is an unnecessary
use of resources.
- The bot is currently hosted locally, and is planned to be migrated to a hosting service. This change will occur with 
Version 1.1.0.