### PR TITLE
Version 1.1.0

### DIFF
--- a/.conf/prod_config.json
+++ b/.conf/prod_config.json
@@ -1,7 +1,11 @@
 {
+  "token": "TOKEN",
   "server": 828122715780939786,
+  "admin": 828122715838742536,
   "log_channel": 1016982786059542559,
   "max_messages": 300000,
+  "backlog_length": 30,
   "log_history": 3,
-  "ignored_categories": [858060453607374860, 910345180593414194]
+  "ignored_categories": [828122716360015886, 828122716360015889, 858060453607374860, 910345180593414194],
+  "read_cache_file": false
 }

--- a/.conf/prod_config.json
+++ b/.conf/prod_config.json
@@ -7,5 +7,6 @@
   "backlog_length": 30,
   "log_history": 3,
   "ignored_categories": [828122716360015886, 828122716360015889, 858060453607374860, 910345180593414194],
+  "dm_probability": 0.0025,
   "read_cache_file": false
 }

--- a/.conf/test_config.json
+++ b/.conf/test_config.json
@@ -7,5 +7,6 @@
   "backlog_length": 30,
   "log_history": 3,
   "ignored_categories": [1017687958171680779],
+  "dm_probability": 0.5,
   "read_cache_file": true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Keys
+*.ppk

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ able to query Celestia directly for this information will make monitoring the bo
 - The command "+error" now causes Celestia to throw an error. This, along with "+info", can only be called by admins in
 the logs channel.
   - The purpose of this command is to be able to access and test an error message without an error actually occurring.
+- Celestia now has a 1 in 500 probability of DMing a member the "celestia caught in 4k" sticker when the user edits
+or deletes a message.
 ### Bug Fixes
 - Fixed a bug that caused Celestia to read content strings in the cache file to be interpreted in the wrong encoding
 scheme.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,41 @@ UW Genshin Discord's custom moderation bot.
 Celestia monitors and logs edit and delete actions on the server for the purposes of accountability and safety.
 For questions about the bot, please contact RicePulp#0077 and/or Purost#1025.
 
-## Version 1.0.3
+## Version 1.1.0
 Released on XXXX
+### Features
+- Celestia is now hosted on Amazon Web Service (AWS) EC2. This change ensures that uptime on the bot is not reliant on 
+uptime of a personal computer, especially one that needs to be turned off for an extended period of time in the near 
+future. This also prevents the devs from accidentally stopping the process running the bot.
+  - EC2 is free for an entire year, after which cost is around $5/month.
+- Celestia's "+info" command now displays more information about Celestia's internal state, such as memory consumption
+and cache writing execution times.
+  - This is especially important as after hosting, the console and console logs will be much harder to access, so being
+able to query Celestia directly for this information will make monitoring the bot much simpler.
+- The command "+error" now causes Celestia to throw an error. This, along with "+info", can only be called by admins in
+the logs channel.
+  - The purpose of this command is to be able to access and test an error message without an error actually occurring.
+### Bug Fixes
+- Fixed a bug that caused Celestia to read content strings in the cache file to be interpreted in the wrong encoding
+scheme.
+  - Technically, nothing had to be done to fix this bug as it was never a bug in the first place. The dev team only
+    logged this bug because the log structure looked wrong, but it turns out that everything was actually working as
+    intended.
+- Fixed a bug that prevented Celestia from providing extra context on error messages.
+### Other changes
+- Small consistency/wording changes to previous version logs.
+### Known issues
+- None so far, but the dev team will be monitoring the bot closely over the next few days to ensure everything is going
+smoothly with the transfer to AWS EC2.
+- The dev team would also like to note that the updated sticker handling is still on the to-do list; it has not been
+forgotten.
+
+## Version 1.0.3
+Released on 2022-09-15 13:23-07:00.
 ### Features
 - The 'Welcome' and 'Important' categories in the server are no longer monitored by Celestia.
 - Delete logs now also include attachment information for context messages.
-- The command "+info" now displays basic information about the bot and its current status.
+- The command "+info" now displays basic information about Celestia and its current status.
 ### Bug fixes
 - Fixed an issue that caused context messages with textual content to appear as if they had no textual content.
   - This issue also could sometimes cause Celestia to error out.
@@ -17,9 +46,10 @@ Released on XXXX
 - Celestia's error logs now print more context on the immediate cause of the error.
 - README.md now includes the time that each version was pushed.
 ### Known issues
-- Messages that were cached in the cache file render as raw strings instead of in the proper encoding scheme (UTF-16).
-  - Until this issue is fixed, fast booting may cause unexpected rendering errors, so unfortunately we must still use 
-    slow-booting.
+- ~~Messages that were cached in the cache file render as raw strings instead of in the proper encoding scheme (UTF-16).~~
+**Addressed in Version 1.1.0.**
+  - ~~Until this issue is fixed, fast booting may cause unexpected rendering errors, so unfortunately we must still use 
+    slow-booting.~~
 
 ## Version 1.0.2
 Released on 2022-09-13 00:08-07:00.
@@ -64,8 +94,8 @@ name surrounded by colons as if it were an emote.
 section. It should also display the attachments remaining after the edit.~~ **Addressed in Version 1.0.2.**
 - ~~Currently, after a message is deleted, the message cache still lives in the internal cache, which is an unnecessary
 use of resources.~~ **Addressed in Version 1.0.2.**
-- The bot is currently hosted locally, and is planned to be migrated to a hosting service. This change will occur with 
-Version 1.1.0.
+- ~~The bot is currently hosted locally, and is planned to be migrated to a hosting service. This change will occur with 
+Version 1.1.0.~~ **Addressed in Version 1.1.0.**
 
 ## Version 1.0.0
 Released on 2022-09-10 22:32-07:00.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ able to query Celestia directly for this information will make monitoring the bo
 - The command "+error" now causes Celestia to throw an error. This, along with "+info", can only be called by admins in
 the logs channel.
   - The purpose of this command is to be able to access and test an error message without an error actually occurring.
-- Celestia now has a 1 in 500 probability of DMing a member the "celestia caught in 4k" sticker when the user edits
-or deletes a message.
+- Celestia now has a 1 in 500 probability of DMing a member a message when the user edits or deletes a message.
 ### Bug Fixes
 - Fixed a bug that caused Celestia to read content strings in the cache file to be interpreted in the wrong encoding
 scheme.

--- a/main.py
+++ b/main.py
@@ -163,19 +163,22 @@ async def populate_cache():
 async def notify_error(error: str, message_model: MessageModel = None):
     new_line = '\n'
     print(error)
+    message_str = f'{new_line + f"From message id {message_model.message_id}"}' if message_model is not None else ''
+    channel_str = f'{new_line + f"From channel {bot.get_channel(message_model.channel_id).mention}"}' if message_model is not None else ''
+    user_str = f'{new_line + f"From user {bot.get_user(message_model.user_id).name}"}' if message_model is not None else ''
     await bot.get_channel(log_channel).send(content=(f'Celestia ran into an error! Please contact the bot dev with '
                                                      f'the following stacktrace: ```{error}'
-                                                     f'{new_line + f"From message id {message_model.message_id}"}' if message_model is not None else ''
-                                                                                                                                                     f'{new_line + f"From channel {bot.get_channel(message_model.channel_id).mention}"}' if message_model is not None else ''
-                                                                                                                                                                                                                                                                           f'{new_line + f"From user {bot.get_user(message_model.user_id).name}"}' if message_model is not None else ''
-                                                                                                                                                                                                                                                                                                                                                                                     f'```'))
+                                                     f'{message_str}'
+                                                     f'{channel_str}'
+                                                     f'{user_str}'
+                                                     f'```'))
 
 
 def get_metrics() -> str:
     length = message_cache.len()
     size = message_cache.__sizeof__()
-    ret_str = (f'Cache length: {length}' + '\n' + f'Cache size: {size}' + '\n'
-                                                                          f'Average entry size: {round(size / length, 2)}')
+    ret_str = (f'Cache length: {length} entries' + '\n' + f'Cache size: {size} bytes' + '\n'
+               f'Average entry size: {round(size / length, 2)} bytes')
     return ret_str
 
 
@@ -259,8 +262,8 @@ async def print_cache():
 async def get_info(ctx: commands.Context):
     if ctx.message.channel.id == log_channel and ctx.author.get_role(admin_role) is not None:
         content = (f'```Running version {version}' + '\n' + f'Celestia has been running for '
-                                                            f'{str(datetime.datetime.now(get_timezone()) - start_time).split(".")[0]}' + '\n'
-                                                                                                                                         f'{get_metrics()}```')
+                   f'{str(datetime.datetime.now(get_timezone()) - start_time).split(".")[0]}' + '\n'
+                   f'{get_metrics()}```')
         await bot.get_channel(log_channel).send(content=content)
 
 

--- a/main.py
+++ b/main.py
@@ -176,7 +176,7 @@ async def notify_error(error: str, message_model: MessageModel = None):
                                                      f'```'))
 
 
-async def send_dm_sticker(user_id: int):
+async def send_dm_message(user_id: int):
     if random.random() < dm_probability:
         user: discord.User = bot.get_user(user_id)
         await user.send(content='Celestia is watching you...')
@@ -219,7 +219,7 @@ async def on_raw_message_edit(payload: discord.RawMessageUpdateEvent):
             if before is not None and not before.total_eq(after):
                 embed = await create_edit_log_embed(before=before, after=after)
                 await bot.get_channel(log_channel).send(embed=embed)
-                await send_dm_sticker(after.user_id)
+                await send_dm_message(after.user_id)
     except:
         await notify_error(traceback.format_exc(limit=None), message_model=after)
 
@@ -237,7 +237,7 @@ async def on_raw_message_delete(payload: discord.RawMessageDeleteEvent):
             if message is not None:
                 embed = await create_delete_log_embed(message=message)
                 await bot.get_channel(log_channel).send(embed=embed)
-                await send_dm_sticker(message.user_id)
+                await send_dm_message(message.user_id)
     except:
         await notify_error(traceback.format_exc(limit=None), message_model=message)
 

--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ i: int = 0
 pdt = datetime.timezone(-datetime.timedelta(hours=7))
 pst = datetime.timezone(-datetime.timedelta(hours=8))
 is_setting_up = True
-start_time: datetime.datetime = None
+start_time: datetime.datetime | None = None
 
 # bot setup
 bot_token: str = os.getenv(token)
@@ -161,15 +161,14 @@ async def populate_cache():
 
 
 async def notify_error(error: str, message_model: MessageModel = None):
-    new_line = '\n'
     print(error)
-    message_str = f'{new_line + f"From message id {message_model.message_id}"}' if message_model is not None else ''
-    channel_str = f'{new_line + f"From channel {bot.get_channel(message_model.channel_id).mention}"}' if message_model is not None else ''
-    user_str = f'{new_line + f"From user {bot.get_user(message_model.user_id).name}"}' if message_model is not None else ''
+    message_str = f'{f"From message id {message_model.message_id}"}' if message_model is not None else ''
+    channel_str = f'{f"From channel {bot.get_channel(message_model.channel_id).name}"}' if message_model is not None else ''
+    user_str = f'{f"From user {bot.get_user(message_model.user_id).name}"}' if message_model is not None else ''
     await bot.get_channel(log_channel).send(content=(f'Celestia ran into an error! Please contact the bot dev with '
                                                      f'the following stacktrace: ```{error}'
-                                                     f'{message_str}'
-                                                     f'{channel_str}'
+                                                     f'{message_str}' + '\n'
+                                                     f'{channel_str}' + '\n'
                                                      f'{user_str}'
                                                      f'```'))
 

--- a/main.py
+++ b/main.py
@@ -179,7 +179,7 @@ async def notify_error(error: str, message_model: MessageModel = None):
 async def send_dm_sticker(user_id: int):
     if random.random() < dm_probability:
         user: discord.User = bot.get_user(user_id)
-        await user.send(stickers=[await bot.fetch_sticker(celestia_caught)])
+        await user.send(content='Celestia is watching you...')
 
 
 def get_metrics() -> str:
@@ -208,7 +208,7 @@ def to_json(obj):
 
 @bot.event
 async def on_raw_message_edit(payload: discord.RawMessageUpdateEvent):
-    after_message = None
+    after = None
     try:
         if not is_setting_up:
             after_message = await bot.get_channel(payload.channel_id).get_partial_message(payload.message_id).fetch()
@@ -221,7 +221,7 @@ async def on_raw_message_edit(payload: discord.RawMessageUpdateEvent):
                 await bot.get_channel(log_channel).send(embed=embed)
                 await send_dm_sticker(after.user_id)
     except:
-        await notify_error(traceback.format_exc(limit=None), message_model=after_message)
+        await notify_error(traceback.format_exc(limit=None), message_model=after)
 
 
 @bot.event


### PR DESCRIPTION
## Version 1.1.0
Released on XXXX
### Features
- Celestia is now hosted on Amazon Web Service (AWS) EC2. This change ensures that uptime on the bot is not reliant on 
uptime of a personal computer, especially one that needs to be turned off for an extended period of time in the near 
future. This also prevents the devs from accidentally stopping the process running the bot.
  - EC2 is free for an entire year, after which cost is around $5/month.
- Celestia's "+info" command now displays more information about Celestia's internal state, such as memory consumption
and cache writing execution times.
  - This is especially important as after hosting, the console and console logs will be much harder to access, so being
able to query Celestia directly for this information will make monitoring the bot much simpler.
- The command "+error" now causes Celestia to throw an error. This, along with "+info", can only be called by admins in
the logs channel.
  - The purpose of this command is to be able to access and test an error message without an error actually occurring.
- Celestia now has a 1 in 500 probability of DMing a member a message when the user edits or deletes a message.
### Bug Fixes
- Fixed a bug that caused Celestia to read content strings in the cache file to be interpreted in the wrong encoding
scheme.
  - Technically, nothing had to be done to fix this bug as it was never a bug in the first place. The dev team only
    logged this bug because the log structure looked wrong, but it turns out that everything was actually working as
    intended.
- Fixed a bug that prevented Celestia from providing extra context on error messages.
### Other changes
- Small consistency/wording changes to previous version logs.
### Known issues
- None so far, but the dev team will be monitoring the bot closely over the next few days to ensure everything is going
smoothly with the transfer to AWS EC2.
- The dev team would also like to note that the updated sticker handling is still on the to-do list; it has not been
forgotten.