### PR TITLE
Version 1.1.1. See README.md for details.

### DIFF
--- a/.conf/prod_config.json
+++ b/.conf/prod_config.json
@@ -1,12 +1,14 @@
 {
   "token": "TOKEN",
+  "celestia_id": 1017674026325389322,
   "server": 828122715780939786,
   "admin": 828122715838742536,
   "log_channel": 1016982786059542559,
+  "dev_channel": 1021299063645294622,
   "max_messages": 300000,
   "backlog_length": 30,
   "log_history": 3,
   "ignored_categories": [828122716360015886, 828122716360015889, 858060453607374860, 910345180593414194],
-  "dm_probability": 0.0025,
-  "read_cache_file": false
+  "dm_probability": 0.01,
+  "read_cache_file": true
 }

--- a/.conf/test_config.json
+++ b/.conf/test_config.json
@@ -1,8 +1,10 @@
 {
   "token": "TEST_TOKEN",
+  "celestia_id": 1019050145985339422,
   "server": 790789893071962132,
   "admin": 1020015483853996163,
   "log_channel": 1017687912000790588,
+  "dev_channel": 790789893071962135,
   "max_messages": 300000,
   "backlog_length": 30,
   "log_history": 3,

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # Keys
 *.ppk
+/celestia-logs.txt

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ UW Genshin Discord's custom moderation bot.
 Celestia monitors and logs edit and delete actions on the server for the purposes of accountability and safety.
 For questions about the bot, please contact RicePulp#0077 and/or Purost#1025.
 
+## Version 1.1.1
+Released on XXXX.
+### Features
+- Celestia now automatically reacts to all log and error messages with the "✉" (UTF-16 0x2709) emoji. If an admin
+also reacts with the envelope, the message is copied into the Celestia channel. Note that this only works for log
+messages sent since the most recent boot due to Discord limitations.
+  - This change is aimed at making sharing issues with Celestia faster and easier. Working around the said limitation
+is possible but, as of right now, it doesn't seem worth working around for now.
+- Celestia now sends an attachment form of the "caught by celestia in 4k" sticker to users as opposed to a cryptic 
+"Celestia is watching you..."
+### Bug Fixes
+None.
+### Other changes
+- Celestia now writes to a file instead of to console. This makes accessing what originally was console output
+accessible even in the EC2 instance.
+- The chance that Celestia sends the aforementioned image to a user upon an edit or delete has been increased from
+1 in 500 to 1 in 100.
+- Small code QOL changes.
+### Known issues
+- Celestia does not note the reply status of a message in the log entries; that is, right now it is impossible to look
+at a log entry and know to which message a post was replying to, if applicable.
+
 ## Version 1.1.0
 Released on 2022-09-18 16:18-07:00.
 ### Features


### PR DESCRIPTION
## Version 1.1.1
Released on 2022-09-26 17:14-07:00.
### Features
- Celestia now automatically reacts to all log and error messages with the "✉" (UTF-16 0x2709) emoji. If an admin
also reacts with the envelope, the message is copied into the Celestia channel. Note that this only works for log
messages sent since the most recent boot due to Discord limitations.
  - This change is aimed at making sharing issues with Celestia faster and easier. Working around the said limitation
is possible but, as of right now, it doesn't seem worth working around for now.
- Celestia now sends an attachment form of the "caught by celestia in 4k" sticker to users as opposed to a cryptic 
"Celestia is watching you..."
### Bug Fixes
None.
### Other changes
- Celestia now writes to a file instead of to console. This makes accessing what originally was console output
accessible even in the EC2 instance.
- The chance that Celestia sends the aforementioned image to a user upon an edit or delete has been increased from
1 in 500 to 1 in 100.
- Small code QOL changes.
### Known issues
- Celestia does not note the reply status of a message in the log entries; that is, right now it is impossible to look
at a log entry and know to which message a post was replying to, if applicable.