### PR TITLE
Version 1.2.0. See README.md for details.

### DIFF
--- a/.conf/prod_config.json
+++ b/.conf/prod_config.json
@@ -10,5 +10,6 @@
   "log_history": 3,
   "ignored_categories": [828122716360015886, 828122716360015889, 858060453607374860, 910345180593414194],
   "dm_probability": 0.01,
-  "read_cache_file": true
+  "read_cache_file": true,
+  "birthday_channel_id": 1034180398101577788
 }

--- a/.conf/test_config.json
+++ b/.conf/test_config.json
@@ -10,5 +10,6 @@
   "log_history": 3,
   "ignored_categories": [1017687958171680779],
   "dm_probability": 0.5,
-  "read_cache_file": true
+  "read_cache_file": false,
+  "birthday_channel_id": 1034134065995059262
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ UW Genshin Discord's custom moderation bot.
 Celestia monitors and logs edit and delete actions on the server for the purposes of accountability and safety.
 For questions about the bot, please contact RicePulp#0077 and/or Purost#1025.
 
+## Version 1.2.0
+Released on XXXX.
+### Features
+- Celestia now counts pings in the birthday event channel. Ping count can be retrieved via the "+giveaway" command after 
+the giveaway ends.
+- Celestia now spoilers images in logs if they were spoilered when they were originally posted.
+- "+status" is now the default command that retrieves Celestia's current state. "+info" is aliased to the status
+command.
+- Celestia now indicates whether a log message has already been sent to the bot developers via removing the "✉" emoji
+and replacing it with the "📮" emoji. This also ensures that a log message cannot be sent twice.
+### Bug fixes
+None.
+### Other changes
+None.
+### Known issues
+- Currently, images cannot be automatically shared to devs by reacting with the mail emoji.
+- Due to some edge case behavior regarding replies, rollout of the reply indication in logs as mentioned in the
+Known issues section of 1.1.1 is delayed, and will hopefully be implemented next patch.
+
 ## Version 1.1.2
 Released on 2022-10-30 22:00-07:00.
 ### Features
@@ -21,8 +40,8 @@ malformed or otherwise strange.
 - After discussion with the mods, it has been determined that the current representation of stickers is sufficient and
 therefore the dev team will not look back into putting stickers in picture form into logs.
 ### Known issues
-- It is possible for Celestia to repost the same log message multiple times by reacting to the same log message multiple
-times.
+- ~~It is possible for Celestia to repost the same log message multiple times by reacting to the same log message multiple
+times.~~ **Addressed in Version 1.2.0.**
 - At roughly 1am PDT on October 9, 2022, Celestia encountered a series of errors that ultimately resulted in Celestia
 attempting to boot multiple instances of itself, EC2 booting up the test bot, and logs being in an untrustworthy state
 from that time to roughly 8am of the same day due to the developers being asleep. The cause is currently believed to be

--- a/message_model.py
+++ b/message_model.py
@@ -2,10 +2,10 @@ import discord
 import json
 
 
-def _list_attachments(attachments: list[discord.Attachment]) -> list[str]:
-    str_list: list[str] = []
+def _list_attachments(attachments: list[discord.Attachment]) -> list[(str, bool)]:
+    str_list: list[(str, bool)] = []
     for i in range(len(attachments)):
-        str_list.append(attachments[i].proxy_url)
+        str_list.append((attachments[i].proxy_url, attachments[i].is_spoiler()))
     return str_list
 
 
@@ -20,7 +20,7 @@ class MessageModel:
             self.user_id: int = message.author.id
             self.content: str = message.content
             self.sticker: int = 0 if len(message.stickers) <= 0 else message.stickers[0].id
-            self.attachments: list[str] = _list_attachments(message.attachments)
+            self.attachments: list[(str, bool)] = _list_attachments(message.attachments)
             if self.content == '':
                 self.content = '*[Empty message body]*'
         elif payload is not None:
@@ -29,7 +29,7 @@ class MessageModel:
             self.user_id: int = 0
             self.content: str = ''
             self.sticker: int = 0
-            self.attachments: list[str] = []
+            self.attachments: list[(str, bool)] = []
         else:
             self.__dict__.update(kwargs['dict'])
 
@@ -65,7 +65,8 @@ class MessageModel:
 
     def total_eq(self, other):
         return (self.message_id == other.message_id and self.content == other.content
-                and self.sticker == other.sticker and ''.join(self.attachments) == ''.join(other.attachments))
+                and self.sticker == other.sticker and len(self.attachments) == len(other.attachments)
+                and self.attachments[i][0] == other.attachments[i][0] for i in range(len(self.attachments)))
 
     @staticmethod
     def is_image(url: str) -> str | None:


### PR DESCRIPTION
## Version 1.2.0
Released on 2022-11-20 20:36-08:00.
### Features
- Celestia now counts pings in the birthday event channel. Ping count can be retrieved via the "+giveaway" command after 
the giveaway ends.
- Celestia now spoilers images in logs if they were spoilered when they were originally posted.
- "+status" is now the default command that retrieves Celestia's current state. "+info" is aliased to the status
command.
- Celestia now indicates whether a log message has already been sent to the bot developers via removing the "✉" emoji
and replacing it with the "📮" emoji. This also ensures that a log message cannot be sent twice.
### Bug fixes
None.
### Other changes
None.
### Known issues
- Currently, images cannot be automatically shared to devs by reacting with the mail emoji.
- Due to some edge case behavior regarding replies, rollout of the reply indication in logs as mentioned in the
Known issues section of 1.1.1 is delayed, and will hopefully be implemented next patch.